### PR TITLE
[Feat] 출입구 좌표 조회 API 구현

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/CapstoneApplication.java
+++ b/src/main/java/com/inha/capstone/capstone/CapstoneApplication.java
@@ -1,4 +1,4 @@
-package com.inha.capstone.capstone;  // 패키지 경로
+package com.inha.capstone.capstone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/inha/capstone/capstone/controller/GatePointController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/GatePointController.java
@@ -1,0 +1,23 @@
+package com.inha.capstone.capstone.controller;
+
+import com.inha.capstone.capstone.entity.GatePoint;
+import com.inha.capstone.capstone.repository.GatePointRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/gate-points")
+public class GatePointController {
+
+    private final GatePointRepository gatePointRepository;
+
+    public GatePointController(GatePointRepository gatePointRepository) {
+        this.gatePointRepository = gatePointRepository;
+    }
+
+    @GetMapping
+    public List<GatePoint> getAllGatePoints() {
+        return gatePointRepository.findAll();
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
1. `GatePointController` 생성
   - `/api/gate-points`으로 GET 요청 시, DB에 저장된 출입구 좌표들을 JSON 형태로 응답

2. `@RestController` 기반의 간단한 REST API 구현
   - `GatePointRepository.findAll()`을 이용하여 전체 좌표 조회 기능을 제공

3. 브라우저 테스트 완료
   - `http://localhost:8080/api/gate-points` 접속 시 JSON 응답 확인


### ✅ 테스트 결과
서버 동작 후 브라우저에서 확인한 결과, DB에 넣은 데이터들이 JSON 형식으로 반환
![화면 캡처 2025-04-13 200603](https://github.com/user-attachments/assets/981340aa-06f9-494b-999e-56f2fed57fd8)

### 💬 다음 단계
- React 프론트엔드에서 API를 호출하여 지도 위에 마커로 좌표 시각화