### PR TITLE
[Feat] 출입구 좌표 반환용 API 구현 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/config/WebConfig.java
+++ b/src/main/java/com/inha/capstone/capstone/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.inha.capstone.capstone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:5173")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
1. 출입구 좌표 조회 API 구현
   - `/api/gate-points` GET 요청 시, DB에 저장된 모든 좌표(JSON) 반환
   - 프론트엔드에서 요청 받은 데이터들 지도에 마커로 표시

2. CORS 설정 추가
   - React에서 API 호출 가능하도록 허용
   - `WebConfig.java`에서 CORS 관련 설정 추가 

3. 테스트 완료
   - 프론트엔드 부분에서 지도에 13개의 마커 정상 표시됨 확인
   - Google Maps API 기반 [지도 중심: 인하대학교]

### ✅ 테스트 결과
![gasd](https://github.com/user-attachments/assets/8474db98-53bc-4058-850c-1654840bb212)

