### PR TITLE
[Feat] 도로 중심 좌표용 RoadCenter 테이블 및 API 구현, 데이터 등록/조회 기능 추가

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/RoadCenterRunnerTest.java
+++ b/src/main/java/com/inha/capstone/capstone/RoadCenterRunnerTest.java
@@ -1,0 +1,34 @@
+package com.inha.capstone.capstone;
+
+import com.inha.capstone.capstone.entity.RoadCenter;
+import com.inha.capstone.capstone.repository.RoadCenterRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RoadCenterRunnerTest implements CommandLineRunner {
+
+    private final RoadCenterRepository roadCenterRepository;
+
+    public RoadCenterRunnerTest(RoadCenterRepository roadCenterRepository) {
+        this.roadCenterRepository = roadCenterRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        List<RoadCenter> centers = roadCenterRepository.findAll();
+
+        if (centers.isEmpty()) {
+            System.out.println("road_centers 테이블에 저장된 데이터가 없습니다.");
+        } else {
+            System.out.println("road_centers 테이블에 저장된 도로 중심 좌표 목록:");
+            for (RoadCenter rc : centers) {
+                System.out.println("ID: " + rc.getId()
+                        + ", 위도: " + rc.getLatitude()
+                        + ", 경도: " + rc.getLongitude());
+            }
+        }
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/controller/RoadCenterController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/RoadCenterController.java
@@ -1,0 +1,33 @@
+package com.inha.capstone.capstone.controller;
+
+import com.inha.capstone.capstone.entity.RoadCenter;
+import com.inha.capstone.capstone.repository.RoadCenterRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/road-centers")
+public class RoadCenterController {
+
+    private final RoadCenterRepository repository;
+
+    public RoadCenterController(RoadCenterRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<RoadCenter> getAllRoadCenters() {
+        return repository.findAll();
+    }
+
+
+    @PostMapping("/bulk")
+    public List<RoadCenter> insertRoadCenters(@RequestBody List<RoadCenter> roadCenters) {
+        /*  현재는 사용하지 않지만, 확장을 위해 post 코드 작성
+            프론트엔드나 Postman에서 도로 중심 좌표를 등록할 수 있도록 API 생성
+            지도에서 클릭한 좌표를 중심으로 좌표를 저장할수도 있지 않을까?
+        */
+        return repository.saveAll(roadCenters);
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/entity/RoadCenter.java
+++ b/src/main/java/com/inha/capstone/capstone/entity/RoadCenter.java
@@ -3,8 +3,8 @@ package com.inha.capstone.capstone.entity;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "gate_points") // DB 테이블 (건물의 출입구 좌표들)
-public class GatePoint {
+@Table(name = "road_centers")
+public class RoadCenter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -16,15 +16,12 @@ public class GatePoint {
     @Column(nullable = false)
     private double longitude;
 
+    public RoadCenter() {}
 
-    public GatePoint() {}
-
-
-    public GatePoint(double latitude, double longitude) {
+    public RoadCenter(double latitude, double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
     }
-
 
     public Long getId() {
         return id;

--- a/src/main/java/com/inha/capstone/capstone/repository/RoadCenterRepository.java
+++ b/src/main/java/com/inha/capstone/capstone/repository/RoadCenterRepository.java
@@ -1,0 +1,9 @@
+package com.inha.capstone.capstone.repository;
+
+import com.inha.capstone.capstone.entity.RoadCenter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoadCenterRepository extends JpaRepository<RoadCenter, Long> {
+}


### PR DESCRIPTION
### 📝 작업 내용 
1. road_centers 테이블을 위한 Entity 클래스 RoadCenter.java 생성
 -  위도(latitude), 경도(longitude) 필드 포함
 -  PostgreSQL DB에 생성한 road_centers 테이블과 매핑 설정

2. Repository 인터페이스 RoadCenterRepository.java 생성
 - Spring Data JPA 사용

3. GET /api/road-centers API 구현 (RoadCenterController.java)
 - 프론트엔드 또는 브라우저에서 도로 중심 좌표 목록 확인

4. POST /api/road-centers/bulk API 구현
 -  도로 중심 좌표 데이터를 JSON 배열 형태로 한 번에 등록 
 -  현재 직접적인 사용 X 
5. RoadCenterRunnerTest.java 추가
 - 앱 실행 시 도로 중심 좌표 데이터를 콘솔에 출력
 

### ✅ 테스트 결과
애플리케이션 실행 시 road_centers 테이블에서 13개의 좌표 정상 조회 및 콘솔 출력 확인

브라우저에서 GET /api/road-centers 요청 성공 → JSON 형식으로 응답 정상 확인

PostgreSQL + Spring Data JPA 연동 정상 작동

### 💬 다음 단계
프론트엔드 React에서 Google Maps를 활용해 도로 중심 좌표들 마커(Marker)로 시각화 예정

지도 상의 각 건물 중심이나 도로 위치 표시 기능 구현

도로 경로 시각화? (이건 좀 고민해봐야할듯)