### PR TITLE
[Feat] 도로 중심점 간 연결을 위한 RoadLink 기능 구현 (엔티티, 서비스, 컨트롤러, API 포함)

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/controller/RoadLinkController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/RoadLinkController.java
@@ -1,0 +1,28 @@
+package com.inha.capstone.capstone.controller;
+
+import com.inha.capstone.capstone.entity.RoadLink;
+import com.inha.capstone.capstone.service.RoadLinkService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/road-links")
+public class RoadLinkController {
+
+    private final RoadLinkService service;
+
+    public RoadLinkController(RoadLinkService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<RoadLink> getAll() {
+        return service.getAllLinks();
+    }
+
+    @PostMapping
+    public RoadLink createLink(@RequestParam Long fromId, @RequestParam Long toId) {
+        return service.createLink(fromId, toId);
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/entity/RoadLink.java
+++ b/src/main/java/com/inha/capstone/capstone/entity/RoadLink.java
@@ -1,0 +1,39 @@
+package com.inha.capstone.capstone.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "road_links")
+public class RoadLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "from_center_id", nullable = false)
+    private RoadCenter from;
+
+    @ManyToOne
+    @JoinColumn(name = "to_center_id", nullable = false)
+    private RoadCenter to;
+
+    public RoadLink() {}
+
+    public RoadLink(RoadCenter from, RoadCenter to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public RoadCenter getFrom() {
+        return from;
+    }
+
+    public RoadCenter getTo() {
+        return to;
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/repository/RoadLinkRepository.java
+++ b/src/main/java/com/inha/capstone/capstone/repository/RoadLinkRepository.java
@@ -1,0 +1,9 @@
+package com.inha.capstone.capstone.repository;
+
+import com.inha.capstone.capstone.entity.RoadLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoadLinkRepository extends JpaRepository<RoadLink, Long> {
+}

--- a/src/main/java/com/inha/capstone/capstone/service/RoadLinkService.java
+++ b/src/main/java/com/inha/capstone/capstone/service/RoadLinkService.java
@@ -1,0 +1,34 @@
+package com.inha.capstone.capstone.service;
+
+import com.inha.capstone.capstone.entity.RoadCenter;
+import com.inha.capstone.capstone.entity.RoadLink;
+import com.inha.capstone.capstone.repository.RoadCenterRepository;
+import com.inha.capstone.capstone.repository.RoadLinkRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class RoadLinkService {
+
+    private final RoadLinkRepository roadLinkRepository;
+    private final RoadCenterRepository roadCenterRepository;
+
+    public RoadLinkService(RoadLinkRepository roadLinkRepository, RoadCenterRepository roadCenterRepository) {
+        this.roadLinkRepository = roadLinkRepository;
+        this.roadCenterRepository = roadCenterRepository;
+    }
+
+    public List<RoadLink> getAllLinks() {
+        return roadLinkRepository.findAll();
+    }
+
+    public RoadLink createLink(Long fromId, Long toId) {
+        RoadCenter from = roadCenterRepository.findById(fromId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 도로 중심점입니다."));
+        RoadCenter to = roadCenterRepository.findById(toId)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 to_center_id 값입니다."));
+
+        return roadLinkRepository.save(new RoadLink(from, to));
+    }
+}


### PR DESCRIPTION
## 목적

- 인하대학교 캠퍼스 네비게이션 기능을 위해 도로 중심점(RoadCenter) 간의 연결 관계를 원하는 점들을 관리하고, 
 해당 경로를 Polyline으로 시각화할 수 있도록 백엔드 기능을 구현
- 기존엔 프론트에서 단순하게 선만 표시할수 있는 기능을 사용하여 모든 도로 중심점을 순서대로 선으로 자동 연결했음
하지만 이 구조는 “정확한 경로 설계”에 적합하지 않아, 직접 원하는 쌍만 연결할 수 있도록 설계
road_links 테이블을 통해 지정된 원하는 쌍만 선으로 표현 가능하며, 이후 길찾기 알고리즘과도 연동 가능


##  작업 내용

### 1. `road_links` 테이블 생성
 - 도로 중심점 간의 연결 쌍을 저장하기 위한 테이블 생성

### 2. RoadLink Entity 클래스 추가
- RoadCenter 객체를 연결하는 엔티티
- JPA의 @ManyToOne을 이용해 연결된 중심점 데이터를 자동으로 매핑
- 조회 시 연결된 두 지점의 좌표 정보를 함께 응답할 수 있음

### 3. RoadLinkRepository 생성

### 4. RoadLinkService 클래스 구현
- 사용자가 요청한 fromId와 toId를 기반으로 중심점을 조회하고, 연결 생성
- 존재하지 않는 ID에 대한 예외 처리를 포함 (IllegalArgumentException)

###  5. RoadLinkController 구현
- 모든 연결 리스트를 GET을 통해 조회 
- 두 중심점 연결 추가를 POST를 통해 생성 



