### PR TITLE
[Feat] Flask → Spring 실시간 GPS 데이터 연동 및 스케줄링 처리 추가

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/config/WebClientConfig.java
+++ b/src/main/java/com/inha/capstone/capstone/config/WebClientConfig.java
@@ -25,7 +25,7 @@ public class WebClientConfig {
         // WebClient Bean 생성
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .baseUrl("https://127.0.0.1")  // Flask HTTPS 주소
+                .baseUrl("https://inhacapstone.p-e.kr")  // 실제 배포된 Flask 주소로 변경
                 .build();
     }
 }

--- a/src/main/java/com/inha/capstone/capstone/dto/GpsDataDTO.java
+++ b/src/main/java/com/inha/capstone/capstone/dto/GpsDataDTO.java
@@ -3,7 +3,7 @@ package com.inha.capstone.capstone.dto;
 public class GpsDataDTO {
     private double latitude;
     private double longitude;
-    private int snr;
+    private double snr;
 
     // getters/setters
     public double getLatitude() {
@@ -22,11 +22,11 @@ public class GpsDataDTO {
         this.longitude = longitude;
     }
 
-    public int getSnr() {
+    public double getSnr() {
         return snr;
     }
 
-    public void setSnr(int snr) {
+    public void setSnr(double snr) {
         this.snr = snr;
     }
 }

--- a/src/main/java/com/inha/capstone/capstone/scheduled/GpsScheduler.java
+++ b/src/main/java/com/inha/capstone/capstone/scheduled/GpsScheduler.java
@@ -1,0 +1,25 @@
+package com.inha.capstone.capstone.scheduled;
+
+import com.inha.capstone.capstone.service.GpsService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GpsScheduler {
+
+    private final GpsService gpsService;
+
+    public GpsScheduler(GpsService gpsService) {
+        this.gpsService = gpsService;
+    }
+
+    @Scheduled(fixedRate = 3000)
+    public void fetchGpsPeriodically() {
+        try {
+            var data = gpsService.fetchCurrentLocation();
+            System.out.println("주기적 위치 수신: " + data.getLatitude() + ", " + data.getLongitude() + " (SNR: " + data.getSnr() + ")");
+        } catch (Exception e) {
+            System.err.println("위치 수신 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/service/GpsService.java
+++ b/src/main/java/com/inha/capstone/capstone/service/GpsService.java
@@ -10,11 +10,9 @@ public class GpsService {
 
     private final WebClient webClient;
 
-    // 의존성 주입 방식으로 코드 변경
     public GpsService(WebClient webClient) {
         this.webClient = webClient;
     }
-
 
     public GpsDataDTO fetchCurrentLocation() {
         try {
@@ -23,9 +21,18 @@ public class GpsService {
                     .retrieve()
                     .bodyToMono(GpsDataDTO.class);
 
-            return response.block();
+            GpsDataDTO data = response.block(); // 동기 방식
+            if (data != null) {
+                System.out.printf("Flask에서 수신한 위치: 위도 %.7f, 경도 %.7f, SNR %.14f\n",
+                        data.getLatitude(), data.getLongitude(), data.getSnr());
+            } else {
+                System.out.println("Flask에서 데이터를 받았지만 내용이 없음.");
+            }
+
+            return data;
         } catch (Exception e) {
-            throw new RuntimeException("Flask 서버와 통신 실패: " + e.getMessage(), e);
+            System.err.println("Flask 서버에서 위치 정보 수신 실패: " + e.getMessage());
+            throw new RuntimeException("Flask 서버와 통신 실패", e);
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 

Android → Flask → Spring 구조에서,
Flask → Spring 간 실시간 GPS 데이터 수신 및 처리 기능을 구현

1. GpsService
   - `WebClient`를 사용하여 Flask 서버의 `/gps` endpoint에서 위도, 경도, SNR 데이터를 받아옴
   - 데이터를 받아올 때 콘솔에 실시간 위치 출력

2. GpsScheduler
   - `@Scheduled(fixedRate = 3000)`를 통해 3초마다 Flask에 위치 요청
   - 수신된 데이터를 콘솔에 로그로 출력 (`📡 주기적 위치 수신:`)

3. WebClientConfig
   - 배포용 도메인 https://inhacapstone.p-e.kr으로  WebClient 설정 


## 테스트결과
아직 앱과 웹에서 배포 서버를 열어보지않아서 테스트는 안해봄 