### PR TITLE
[Refactor] 실시간 GPS 위치 저장 및 최단 경로 계산 방식 리팩토링

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
@@ -1,6 +1,8 @@
 package com.inha.capstone.capstone.controller;
 
+import com.inha.capstone.capstone.dto.GpsDataDTO;
 import com.inha.capstone.capstone.entity.RoadCenter;
+import com.inha.capstone.capstone.service.GpsService;
 import com.inha.capstone.capstone.service.NavigationService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,18 +18,18 @@ import java.util.Map;
 public class NavigationController {
 
     private final NavigationService navigationService;
+    private final GpsService gpsService; // 실시간 위치 사용
 
-    public NavigationController(NavigationService navigationService) {
+    public NavigationController(NavigationService navigationService,GpsService gpsService) {
         this.navigationService = navigationService;
+        this.gpsService = gpsService;
     }
 
     @GetMapping("/shortest-path")
-    public List<Map<String, Double>> getShortestPath(
-            @RequestParam double currentLat,
-            @RequestParam double currentLon,
-            @RequestParam Long destinationId
-    ) {
-        RoadCenter start = navigationService.findNearestCenter(currentLat, currentLon);
+    public List<Map<String, Double>> getShortestPath(@RequestParam Long destinationId) {
+        GpsDataDTO current = gpsService.getLastLocation(); // 실시간 저장 위치 사용
+
+        RoadCenter start = navigationService.findNearestCenter(current.getLatitude(), current.getLongitude());
         RoadCenter end = navigationService.getRoadCenterById(destinationId);
         List<RoadCenter> path = navigationService.findShortestPath(start, end);
 

--- a/src/main/java/com/inha/capstone/capstone/controller/RoadLinkController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/RoadLinkController.java
@@ -26,9 +26,12 @@ public class RoadLinkController {
         return service.createLink(fromId, toId);
     }
 
+    /*
+    이건 수동으로 road_links 생성해주는 코드인데 현 프로젝트 상황상 자동으로 하는게 더 좋을거 같아서 주석 처리 해놓음 (추후에 쓸수도 있어서)
     @PostMapping("/auto-connect")
     public String autoConnect() {
         service.connectSequentialCenters();
         return "자동 연결 완료";
     }
+    */
 }

--- a/src/main/java/com/inha/capstone/capstone/initializer/RoadLinkInitializer.java
+++ b/src/main/java/com/inha/capstone/capstone/initializer/RoadLinkInitializer.java
@@ -1,0 +1,65 @@
+package com.inha.capstone.capstone.initializer;
+
+import com.inha.capstone.capstone.entity.RoadCenter;
+import com.inha.capstone.capstone.entity.RoadLink;
+import com.inha.capstone.capstone.repository.RoadCenterRepository;
+import com.inha.capstone.capstone.repository.RoadLinkRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RoadLinkInitializer {
+
+    private final RoadCenterRepository roadCenterRepository;
+    private final RoadLinkRepository roadLinkRepository;
+
+    @PostConstruct
+    public void initializeRoadLinks() {
+        List<RoadCenter> centers = roadCenterRepository.findAll();
+
+        if (centers.size() < 2) {
+            System.out.println("⚠️ 도로 중심점이 충분하지 않습니다.");
+            return;
+        }
+
+        // 기존에 생성된 링크가 있다면 생략 (중복 방지)
+        if (!roadLinkRepository.findAll().isEmpty()) {
+            System.out.println("ℹ️ 이미 RoadLink 데이터가 존재합니다. 생성을 건너뜁니다.");
+            return;
+        }
+
+        for (int i = 0; i < centers.size() - 1; i++) {
+            RoadCenter from = centers.get(i);
+            RoadCenter to = centers.get(i + 1);
+
+            double distance = calculateDistance(
+                    from.getLatitude(), from.getLongitude(),
+                    to.getLatitude(), to.getLongitude()
+            );
+
+            RoadLink forward = new RoadLink(from, to, distance);
+            RoadLink backward = new RoadLink(to, from, distance); // 양방향 연결
+
+            roadLinkRepository.save(forward);
+            roadLinkRepository.save(backward);
+        }
+
+        System.out.println("✅ RoadLink 자동 생성 완료!");
+    }
+
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+}
+

--- a/src/main/java/com/inha/capstone/capstone/service/GpsLocationHolder.java
+++ b/src/main/java/com/inha/capstone/capstone/service/GpsLocationHolder.java
@@ -1,0 +1,25 @@
+package com.inha.capstone.capstone.service;
+
+import com.inha.capstone.capstone.dto.GpsDataDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GpsLocationHolder {
+    private double latitude;
+    private double longitude;
+    private double snr;
+
+    public synchronized void update(double latitude, double longitude, double snr) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.snr = snr;
+    }
+
+    public synchronized GpsDataDTO getCurrent() {
+        GpsDataDTO dto = new GpsDataDTO();
+        dto.setLatitude(latitude);
+        dto.setLongitude(longitude);
+        dto.setSnr(snr);
+        return dto;
+    }
+}

--- a/src/main/java/com/inha/capstone/capstone/service/GpsService.java
+++ b/src/main/java/com/inha/capstone/capstone/service/GpsService.java
@@ -9,9 +9,11 @@ import reactor.core.publisher.Mono;
 public class GpsService {
 
     private final WebClient webClient;
+    private final GpsLocationHolder gpsHolder;
 
-    public GpsService(WebClient webClient) {
+    public GpsService(WebClient webClient, GpsLocationHolder gpsHolder) {
         this.webClient = webClient;
+        this.gpsHolder = gpsHolder;
     }
 
     public GpsDataDTO fetchCurrentLocation() {
@@ -21,8 +23,10 @@ public class GpsService {
                     .retrieve()
                     .bodyToMono(GpsDataDTO.class);
 
-            GpsDataDTO data = response.block(); // 동기 방식
+            GpsDataDTO data = response.block(); // 동기 방식으로 수신
             if (data != null) {
+                gpsHolder.update(data.getLatitude(), data.getLongitude(), data.getSnr());
+
                 System.out.printf("Flask에서 수신한 위치: 위도 %.7f, 경도 %.7f, SNR %.14f\n",
                         data.getLatitude(), data.getLongitude(), data.getSnr());
             } else {
@@ -34,5 +38,10 @@ public class GpsService {
             System.err.println("Flask 서버에서 위치 정보 수신 실패: " + e.getMessage());
             throw new RuntimeException("Flask 서버와 통신 실패", e);
         }
+    }
+
+    // 메모리에 저장된 위치를 꺼내오는 함수
+    public GpsDataDTO getLastLocation() {
+        return gpsHolder.getCurrent();
     }
 }


### PR DESCRIPTION
## 작업내용
- GpsLocationHolder 컴포넌트 추가로 서버 메모리에 실시간 GPS 위치 저장
- GpsService 수정: Flask에서 위치 수신 후 GpsLocationHolder에 저장
- NavigationController 수정: 프론트에서 위치를 받는 방식 제거하고, 서버 저장 위치 기반으로 최단 경로 계산
- React API 인터페이스 변경 필요: /api/navigation/shortest-path → destinationId만 전달

- 최단경로 API에서 currentLat, currentLon 파라미터 제거