### PR TITLE
[Refactor]: 출입구 이름으로 경로 탐색할 수 있도록 검색 API 구현 및 오류해결 

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
@@ -116,4 +116,11 @@ public class NavigationController {
     public Long getNearestCenterByLatLng(@RequestParam double lat, @RequestParam double lng) {
         return navigationService.findNearestCenter(lat, lng).getId();
     }
+
+    @GetMapping("/gate-id-by-name")
+    public Long getGateIdByName(@RequestParam String name) {
+        GatePoint gate = gatePointRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 출입구가 존재하지 않습니다."));
+        return gate.getId();
+    }
 }

--- a/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
@@ -111,4 +111,9 @@ public class NavigationController {
         RoadCenter nearest = navigationService.findNearestCenter(gate.getLatitude(), gate.getLongitude());
         return nearest.getId();
     }
+
+    @GetMapping("/nearest-center")
+    public Long getNearestCenterByLatLng(@RequestParam double lat, @RequestParam double lng) {
+        return navigationService.findNearestCenter(lat, lng).getId();
+    }
 }

--- a/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
+++ b/src/main/java/com/inha/capstone/capstone/controller/NavigationController.java
@@ -118,7 +118,7 @@ public class NavigationController {
     }
 
     @GetMapping("/gate-id-by-name")
-    public Long getGateIdByName(@RequestParam String name) {
+    public Long getGateIdByName(@RequestParam("name") String name) {
         GatePoint gate = gatePointRepository.findByName(name)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 출입구가 존재하지 않습니다."));
         return gate.getId();

--- a/src/main/java/com/inha/capstone/capstone/entity/GatePoint.java
+++ b/src/main/java/com/inha/capstone/capstone/entity/GatePoint.java
@@ -16,13 +16,17 @@ public class GatePoint {
     @Column(nullable = false)
     private double longitude;
 
+    @Column(nullable = false)
+    private String name;
+
 
     public GatePoint() {}
 
 
-    public GatePoint(double latitude, double longitude) {
+    public GatePoint(double latitude, double longitude, String name) {
         this.latitude = latitude;
         this.longitude = longitude;
+        this.name = name;
     }
 
 
@@ -38,12 +42,20 @@ public class GatePoint {
         return longitude;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public void setLatitude(double latitude) {
         this.latitude = latitude;
     }
 
     public void setLongitude(double longitude) {
         this.longitude = longitude;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
 }

--- a/src/main/java/com/inha/capstone/capstone/repository/GatePointRepository.java
+++ b/src/main/java/com/inha/capstone/capstone/repository/GatePointRepository.java
@@ -4,7 +4,9 @@ import com.inha.capstone.capstone.entity.GatePoint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GatePointRepository extends JpaRepository<GatePoint, Long> {
-
+    Optional<GatePoint> findByName(String name);
 }


### PR DESCRIPTION
### 작업내용

- 사용자가 건물 출입구 이름을 입력하면, 해당 출입구에 대응되는 GatePoint 엔티티의 ID를 반환하는 API 추가
- 반환된 gateId를 기반으로 기존 로직(gate-to-road-center)을 통해 최종 목적지 도로 중심점으로 매핑
- 검색된 결과를 활용해 기존 shortest-path-from-current API에 연동 가능하도록 구조 구성
- GatePoint 관련 부분에 name 필드 및 메서드 추가
- 파라미터 name 명시적 선언으로 처리 문제 해결
- 검색 실패 시 예외 처리 추가

---

###  테스트 결과

1. React에서 출입구 이름 입력 후 검색 버튼 클릭
2. Spring 서버의 `/api/navigation/gate-id-by-name?name=출입구이름` 호출
3. 응답으로 gateId 수신 → gate-to-road-center → shortest-path-from-current까지 연결됨
4. 정상 작동 시 경로가 지도에 폴리라인으로 표시
