### PR TITLE
[Feat]: 최단 경로 도착점에서 가장 가까운 출입구까지 연결 기능 구현

### DIFF
--- a/src/main/java/com/inha/capstone/capstone/repository/GatePointRepository.java
+++ b/src/main/java/com/inha/capstone/capstone/repository/GatePointRepository.java
@@ -4,9 +4,11 @@ import com.inha.capstone.capstone.entity.GatePoint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface GatePointRepository extends JpaRepository<GatePoint, Long> {
     Optional<GatePoint> findByName(String name);
+    List<GatePoint> findByNameContaining(String query);
 }

--- a/src/main/java/com/inha/capstone/capstone/service/NavigationService.java
+++ b/src/main/java/com/inha/capstone/capstone/service/NavigationService.java
@@ -114,4 +114,15 @@ public class NavigationService {
         return roadCenterRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 도로 중심점이 없습니다."));
     }
+
+    public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
 }


### PR DESCRIPTION
### 작업 내용
사용자가 건물 출입구 이름을 입력하면, 해당 출입구에 대응되는 GatePoint 엔티티의 ID를 반환하는 API 추가
반환된 gateId를 기반으로 기존 로직을 통해 최종 목적지 도로 중심점으로 매핑


### 테스트 결과
1. 프론트에서 출입구 이름 입력 후 검색 버튼 클릭

2. Spring 서버의 /api/navigation/gate-id-by-name 출입구이름 호출

3. 응답으로 gateId 수신 → gate-to-road-center → shortest-path-from-current까지 연결됨

4. 정상 작동 시 전체 경로가 지도에 폴리라인으로 시각화됨 (현재 위치 → 도로 중심점 → 최종 출입구)

